### PR TITLE
Affichage du nombre d'heures / jours en décimales

### DIFF
--- a/panel_inscriptions.py
+++ b/panel_inscriptions.py
@@ -880,7 +880,7 @@ class ModeAccueilPanel(InscriptionsTab, PeriodeMixin):
             inscription = self.inscrit.inscriptions[self.periode]
         if inscription:
             self.jours_poses.SetValue(u"%d jours posés / %d jours" % (inscription.GetNombreJoursCongesPoses(), inscription.GetNombreJoursCongesPeriode()))
-            self.heures_and_jours_reference.SetValue(u"%d heures / %d jours" % (inscription.GetNombreHeuresPresenceSemaine(), inscription.GetNombreJoursPresenceSemaine()))
+            self.heures_and_jours_reference.SetValue(u"10.2f heures / %10.2f jours" % (inscription.GetNombreHeuresPresenceSemaine(), inscription.GetNombreJoursPresenceSemaine()))
         else:
             self.jours_poses.SetValue("")
             self.heures_and_jours_reference.SetValue("")


### PR DESCRIPTION
Je propose cette modification que j'ai déjà effectuée pour Optimomes d'afficher en décimales plutôt que de tronquer le résultat. Cela perturbait les directrices (mêmes si on est d'accord que cela ne change strictement rien à part sur cet affichage). 

A toi de voir si tu souhiates l'intégrer ou non.