### PR TITLE
Ajouter un champ <reglement> aux attestations de paiement

### DIFF
--- a/generation/attestation_paiement.py
+++ b/generation/attestation_paiement.py
@@ -134,7 +134,12 @@ class AttestationModifications(object):
             
             if facture_debut is None:
                 continue
-            
+          
+            reglement = 0.0
+            for encaissement in inscrit.famille.encaissements:
+                if encaissement.date and encaissement.date >= self.debut and encaissement.date <= self.fin:
+                    reglement += encaissement.valeur
+
             last_inscription = None
             for tmp in inscrit.inscriptions:
                 if not last_inscription or not last_inscription.fin or (tmp.fin and tmp.fin > last_inscription.fin):
@@ -154,6 +159,7 @@ class AttestationModifications(object):
                 ('ceil-heures-realisees', GetHeureString(math.ceil(heures_realisees))),
                 ('total-sans-activites', "%.2f" % total_sans_activites),
                 ('total', '%.2f' % total),
+                ('reglement', '%.2f' % reglement),
                 ('site', GetNom(site)),
                 ('dernier-mois', GetBoolStr(last_inscription.fin and last_inscription.fin <= facture_fin)),
             ]


### PR DESCRIPTION
Bonjour,
Merci pour le super travail sur Gertrude.

J'essaie de générer des attestations de paiement pour ma crèche, et je constate que le montant utilisé dans l'attestation est le montant facturé sur la période, et non le montant réglé sur la période.

Je propose donc de rajouter un champ "<reglement>" qui peut être utilisé à la place pour obtenir le montant effectivement payé. Je n'ai pas changé le modèle d'attestation pour ne pas affecter les utilisateurs qui préfèreraient le fonctionnement actuel.

En particulier une limitation avec le montant réglé est qu'il est par famille, alors que les attestations sont établies par enfant, donc il faut faire attentation pour les familles avec plusieurs enfants.
De plus je n'ai pas testé mes modifications.

Je ne sais pas si cette pull-request est au bon endroit pour affecter la version Gertrude en ligne ?